### PR TITLE
Add include_all optional parameter to respond_to? method

### DIFF
--- a/lib/blobject.rb
+++ b/lib/blobject.rb
@@ -94,7 +94,7 @@ class Blobject
     super
   end
 
-  def respond_to? method
+  def respond_to? method, include_all=false
     super || self.__respond_to__?(method)
   end
 

--- a/spec/blobject_spec.rb
+++ b/spec/blobject_spec.rb
@@ -126,6 +126,10 @@ describe Blobject do
     it 'returns false for :to_ary because that method is not allowed' do
       refute Blobject.new.respond_to? :to_ary
     end
+
+    it 'accepts the include_all optional parameter' do
+      assert b.respond_to?(:name, false)
+    end
   end
 
   describe 'to_hash' do


### PR DESCRIPTION
When upgrading to RSpec 3.0 method_visibility_for has changed the way that it calls to respond_to? internally.

This caused a "Wrong Number of Arguments" error when being called from rspec as the respond_to? method as defined on blobject.rb only accepted one argument and was being passed two.

This patch adds the include_all optional parameter to respond_to? to conform with default ruby respond_to? behaviour.
